### PR TITLE
Updating image_dim_ordering() to latest api

### DIFF
--- a/keras_layers/keras_layer_L2Normalization.py
+++ b/keras_layers/keras_layer_L2Normalization.py
@@ -44,7 +44,7 @@ class L2Normalization(Layer):
     '''
 
     def __init__(self, gamma_init=20, **kwargs):
-        if K.image_dim_ordering() == 'tf':
+        if K.common.image_dim_ordering() == 'tf':
             self.axis = 3
         else:
             self.axis = 1


### PR DESCRIPTION
Keras 2.3.x have updated keras.backend.image_dim_ordering() to keras.backend.common.image_dim_ordering()